### PR TITLE
fix: check for sudo on system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ on: [push, pull_request]
 name: CI
 
 jobs:
-  install_and_test:
-    name: Install & Test
+  install_latest_and_test:
+    name: Install & Test (latest build))
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -48,10 +48,41 @@ jobs:
           
           echo "this is a test" | extism call test/code.wasm count_vowels
         
-    
-      - name: Test CLI with git install
+
+  install_git_and_test:
+    name: Install & Test (from source)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        rust:
+          - stable
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Setup Python env
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          check-latest: true
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+
+      - name: Install CLI and extism lib
         run: |
-          extism uninstall
+          pip3 install cffi
+          pip3 install .
+          extism -h
+        
           extism install git
-          
+      
+      - name: Test CLI
+        run: |
           echo "this is a test" | extism call test/code.wasm count_vowels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           pip3 install .
           extism -h
         
-          extism install git
+          extism install latest
       
       - name: Test CLI
         run: |
@@ -44,6 +44,14 @@ jobs:
       - name: Test CLI with /usr/local prefix install
         run: |
           extism uninstall
-          extism --prefix /usr/local install
+          extism --prefix /usr/local install latest
+          
+          echo "this is a test" | extism call test/code.wasm count_vowels
+        
+    
+      - name: Test CLI with git install
+        run: |
+          extism uninstall
+          extism install git
           
           echo "this is a test" | extism call test/code.wasm count_vowels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,10 @@ jobs:
       - name: Test CLI
         run: |
           echo "this is a test" | extism call test/code.wasm count_vowels
+
+      - name: Test CLI with /usr/local prefix install
+        run: |
+          extism uninstall
+          extism --prefix /usr/local install
+          
+          echo "this is a test" | extism call test/code.wasm count_vowels

--- a/extism_cli/__init__.py
+++ b/extism_cli/__init__.py
@@ -23,9 +23,12 @@ remote_http = "https://github.com/extism/extism"
 
 # Utils
 
+def has_sudo():
+    return shutil.which("sudo") is not None
+
 
 def cp(src: str, dest: str, sudo: bool = False):
-    if dest.startswith("/usr/"):
+    if dest.startswith("/usr/") and has_sudo():
         sudo = True
     """Copy a file, optionally using sudo"""
     if sudo:
@@ -374,7 +377,7 @@ class ExtismBuilder:
         lib = os.path.join(self.install_prefix, "lib", self.system.lib())
         header = os.path.join(self.install_prefix, "include", "extism.h")
         try:
-            if sudo:
+            if sudo and has_sudo():
                 subprocess.run(["sudo", "rm", "-f", lib])
             else:
                 os.remove(lib)
@@ -383,7 +386,7 @@ class ExtismBuilder:
             self.print(f"Warning: file does not exist {lib}")
 
         try:
-            if sudo:
+            if sudo and has_sudo():
                 subprocess.run(["sudo", "rm", "-f", header])
             else:
                 os.remove(header)


### PR DESCRIPTION
On GitHub Action machines, we're root and no `sudo` is available to call. So I think this should solve the case where we're writing to a privileged location on disk, but don't need to execute sudo to do so.  