### PR TITLE
feat: add `--allow-path` and `--manifest` flags

### DIFF
--- a/extism_cli/__init__.py
+++ b/extism_cli/__init__.py
@@ -185,7 +185,7 @@ call.add_argument("--config",
 call.add_argument("--allow-path",
                   default=[],
                   nargs='*',
-                  help="Provide access to a directory")
+                  help="Provide a plugin access to a host directory, e.g. --allow-path ./host:/plugin")
 call.add_argument("--manifest",
                   default=False,
                   action='store_true',
@@ -590,8 +590,8 @@ def main():
                 args.wasi = True
                 paths = {}
                 for p in args.allow_path:
-                    if '=' in p:
-                        s = p.split('=', maxsplit=1)
+                    if ':' in p:
+                        s = p.split(':', maxsplit=1)
                         paths[s[0]] = s[1]
                     else:
                         paths[p] = p

--- a/extism_cli/__init__.py
+++ b/extism_cli/__init__.py
@@ -182,7 +182,7 @@ call.add_argument("--config",
                   default=[],
                   nargs='*',
                   help="Set a single config value")
-call.add_argument("--path",
+call.add_argument("--allow-path",
                   default=[],
                   nargs='*',
                   help="Provide access to a directory")
@@ -569,10 +569,10 @@ def main():
                     "path": args.wasm
                 }],
             }
-            if len(args.path) > 0:
+            if len(args.allow_path) > 0:
                 args.wasi = True
                 paths = {}
-                for p in args.path:
+                for p in args.allow_path:
                     if '=' in p:
                         s = p.split('=', maxsplit=1)
                         paths[s[0]] = s[1]

--- a/extism_cli/__init__.py
+++ b/extism_cli/__init__.py
@@ -182,6 +182,10 @@ call.add_argument("--config",
                   default=[],
                   nargs='*',
                   help="Set a single config value")
+call.add_argument("--path",
+                  default=[],
+                  nargs='*',
+                  help="Provide access to a directory")
 
 
 class ExtismBuilder:
@@ -560,9 +564,23 @@ def main():
 
         libextism = extism.import_extism()
         with libextism.Context() as ctx:
-            data = open(args.wasm, 'rb').read()
+            manifest = {
+                "wasm": [{
+                    "path": args.wasm
+                }],
+            }
+            if len(args.path) > 0:
+                paths = {}
+                for p in args.path:
+                    if '=' in p:
+                        s = p.split('=', maxsplit=1)
+                        paths[s[0]] = s[1]
+                    else:
+                        paths[p] = p
+                manifest["allowed_paths"] = paths
+
             libextism.set_log_file("stderr", args.log_level)
-            plugin = ctx.plugin(data, wasi=args.wasi, config=config)
+            plugin = ctx.plugin(manifest, wasi=args.wasi, config=config)
             r = plugin.call(args.function, input, parse=None)
             sys.stdout.buffer.write(r)
 

--- a/extism_cli/__init__.py
+++ b/extism_cli/__init__.py
@@ -570,6 +570,7 @@ def main():
                 }],
             }
             if len(args.path) > 0:
+                args.wasi = True
                 paths = {}
                 for p in args.path:
                     if '=' in p:

--- a/extism_cli/__init__.py
+++ b/extism_cli/__init__.py
@@ -186,6 +186,10 @@ call.add_argument("--allow-path",
                   default=[],
                   nargs='*',
                   help="Provide access to a directory")
+call.add_argument("--manifest",
+                  default=False,
+                  action='store_true',
+                  help="Load manifest instead of WASM module")
 
 
 class ExtismBuilder:
@@ -564,11 +568,24 @@ def main():
 
         libextism = extism.import_extism()
         with libextism.Context() as ctx:
-            manifest = {
-                "wasm": [{
-                    "path": args.wasm
-                }],
-            }
+            if args.manifest:
+                with open(args.wasm) as f:
+                    s = f.read().lstrip()
+                    is_json = s[0] == '{'
+                    if is_json:
+                        manifest = json.loads(s)
+                    else:
+                        try:
+                            import toml
+                        except:
+                            import tomllib as toml
+                        manifest = toml.loads(s)
+            else:
+                manifest = {
+                    "wasm": [{
+                        "path": args.wasm
+                    }],
+                }
             if len(args.allow_path) > 0:
                 args.wasi = True
                 paths = {}

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,5 @@ dest=${1-$HOME/.local/bin}
 curl --fail https://raw.githubusercontent.com/extism/cli/main/extism_cli/__init__.py > /tmp/extism-cli
 mv /tmp/extism-cli "$dest"/extism
 chmod +x "$dest"/extism
-pip3 install extism toml cffi --user
 
 echo "\nInstalled 'extism' to ${dest}. Please be sure that is in your system PATH.\n"

--- a/install.sh
+++ b/install.sh
@@ -6,5 +6,6 @@ dest=${1-$HOME/.local/bin}
 curl --fail https://raw.githubusercontent.com/extism/cli/main/extism_cli/__init__.py > /tmp/extism-cli
 mv /tmp/extism-cli "$dest"/extism
 chmod +x "$dest"/extism
+pip3 install extism toml cffi --user
 
 echo "\nInstalled 'extism' to ${dest}. Please be sure that is in your system PATH.\n"

--- a/poetry.lock
+++ b/poetry.lock
@@ -54,7 +54,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7
 
 [[package]]
 name = "docstring-to-markdown"
-version = "0.10"
+version = "0.11"
 description = "On the fly conversion of Python docstrings to markdown"
 category = "dev"
 optional = false
@@ -62,8 +62,8 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "extism"
-version = "0.0.1rc6"
-description = ""
+version = "0.1.0"
+description = "Extism Host SDK for python"
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
@@ -73,7 +73,7 @@ cffi = ">=1.10.0,<2.0.0"
 
 [[package]]
 name = "importlib-metadata"
-version = "5.0.0"
+version = "5.1.0"
 description = "Read metadata from Python packages"
 category = "dev"
 optional = false
@@ -86,11 +86,11 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["sphinx (>=3.5)", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "furo", "jaraco.tidelift (>=1.4)"]
 perf = ["ipython"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "flake8 (<5)", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "flake8 (<5)", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "pytest-flake8", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "jedi"
-version = "0.18.1"
+version = "0.18.2"
 description = "An autocompletion tool for Python that can be used for text editors."
 category = "dev"
 optional = false
@@ -100,8 +100,9 @@ python-versions = ">=3.6"
 parso = ">=0.8.0,<0.9.0"
 
 [package.extras]
+docs = ["Jinja2 (==2.11.3)", "MarkupSafe (==1.1.1)", "Pygments (==2.8.1)", "alabaster (==0.7.12)", "babel (==2.9.1)", "chardet (==4.0.0)", "commonmark (==0.8.1)", "docutils (==0.17.1)", "future (==0.18.2)", "idna (==2.10)", "imagesize (==1.2.0)", "mock (==1.0.1)", "packaging (==20.9)", "pyparsing (==2.4.7)", "pytz (==2021.1)", "readthedocs-sphinx-ext (==2.1.4)", "recommonmark (==0.5.0)", "requests (==2.25.1)", "six (==1.15.0)", "snowballstemmer (==2.1.0)", "sphinx-rtd-theme (==0.4.3)", "sphinx (==1.8.5)", "sphinxcontrib-serializinghtml (==1.1.4)", "sphinxcontrib-websupport (==1.2.4)", "urllib3 (==1.26.4)"]
 qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
-testing = ["Django (<3.1)", "colorama", "docopt", "pytest (<7.0.0)"]
+testing = ["Django (<3.1)", "attrs", "colorama", "docopt", "pytest (<7.0.0)"]
 
 [[package]]
 name = "mypy-extensions"
@@ -235,7 +236,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "ujson"
-version = "5.5.0"
+version = "5.6.0"
 description = "Ultra fast JSON encoder and decoder for Python"
 category = "dev"
 optional = false
@@ -243,7 +244,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "zipp"
-version = "3.10.0"
+version = "3.11.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
@@ -251,7 +252,7 @@ python-versions = ">=3.7"
 
 [package.extras]
 docs = ["sphinx (>=3.5)", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "furo", "jaraco.tidelift (>=1.4)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "flake8 (<5)", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "jaraco.functools", "more-itertools", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "flake8 (<5)", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "jaraco.functools", "more-itertools", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "pytest-flake8"]
 
 [metadata]
 lock-version = "1.1"
@@ -266,10 +267,7 @@ colorama = []
 docstring-to-markdown = []
 extism = []
 importlib-metadata = []
-jedi = [
-    {file = "jedi-0.18.1-py2.py3-none-any.whl", hash = "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d"},
-    {file = "jedi-0.18.1.tar.gz", hash = "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"},
-]
+jedi = []
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},


### PR DESCRIPTION
- A path can be renamed using '=': `--allow-path .=/my/new/path`
- Or exposed using its existing name: `--allow-path .`
- Adds `--manifest` to load manifest from disk instead of WASM module