### PR TITLE
docs: update `README.md` comments to say `/usr/local` instead of `/usr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The simplest use-case is to download an build the source code then install the l
 the installation prefix of your choice.
 
 ```sh
-$ extism install latest # install to /usr/lib and /usr/include
+$ extism install latest # install to /usr/local/lib and /usr/local/include
 $ extism install git # build and install from source
 ```
 


### PR DESCRIPTION
Since the default prefix is `/usr/local`, would it make more sense to change the comments in the `README.md` to reflect where we'll install the library and header file?

Reference: https://github.com/extism/cli/blob/main/extism_cli/__init__.py#L202