### PR TITLE
chore: depend on git version of extism until 0.2 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-extism = "*"
+extism = { git = "https://github.com/extism/extism", subdirectory = "python" }
 
 [tool.poetry.dev-dependencies]
 black = "^22.6.0"


### PR DESCRIPTION
Updates `extism-cli` to depend on the `extism` Python SDK from git instead of the last release - once 0.2 is released we can update this to point to the new release instead.

This will avoid errors on the PDKs like this: https://github.com/extism/c-pdk/actions/runs/3886849232/jobs/6632598214#step:9:29 as we prepare them for the release