### PR TITLE
bug: create the path of the installation directory if it does not exist

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -e
 
 dest=${1-$HOME/.local/bin}
 if [ ! -d "$dest" ]; then
-  mkdir -p $dest
+  mkdir -p "$dest"
 fi
 
 curl --fail https://raw.githubusercontent.com/extism/cli/main/extism_cli/__init__.py > /tmp/extism-cli

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,10 @@
 set -e
 
 dest=${1-$HOME/.local/bin}
+if [ ! -d "$dest" ]; then
+  mkdir -p $dest
+fi
+
 curl --fail https://raw.githubusercontent.com/extism/cli/main/extism_cli/__init__.py > /tmp/extism-cli
 mv /tmp/extism-cli "$dest"/extism
 chmod +x "$dest"/extism


### PR DESCRIPTION
Fixes the issue filed on the `extism` repo: https://github.com/extism/extism/issues/339