### PR TITLE
feat: Support urls to wasms

### DIFF
--- a/extism_cli/__init__.py
+++ b/extism_cli/__init__.py
@@ -170,7 +170,7 @@ info.add_argument("--libs",
 
 # Call subcommand
 call = subparsers.add_parser("call")
-call.add_argument("wasm", help='WASM file')
+call.add_argument("wasm", help='WASM file or url')
 call.add_argument("--input", default=None, help='Plugin input')
 call.add_argument("function", help='Function name')
 call.add_argument("--log-level", default="error", help="Set log level")
@@ -586,11 +586,23 @@ def main():
                             import tomllib as toml
                         manifest = toml.loads(s)
             else:
-                manifest = {
-                    "wasm": [{
-                        "path": args.wasm
-                    }],
-                }
+                from urllib.parse import urlparse
+                pieces = urlparse(args.wasm)
+                if pieces.scheme.lower() in ('http', 'https'):
+                    import urllib.request
+                    f = urllib.request.urlopen(args.wasm)
+                    manifest = {
+                        "wasm": [{
+                            "data": f.read()
+                        }],
+                    }
+                else:
+                    manifest = {
+                        "wasm": [{
+                            "path": args.wasm
+                        }],
+                    }
+
 
             if len(args.allow_path) > 0:
                 args.wasi = True

--- a/extism_cli/__init__.py
+++ b/extism_cli/__init__.py
@@ -589,11 +589,9 @@ def main():
                 from urllib.parse import urlparse
                 pieces = urlparse(args.wasm)
                 if pieces.scheme.lower() in ('http', 'https'):
-                    import urllib.request
-                    f = urllib.request.urlopen(args.wasm)
                     manifest = {
                         "wasm": [{
-                            "data": f.read()
+                            "url": args.wasm
                         }],
                     }
                 else:


### PR DESCRIPTION
Support passing url to wasm in as argument:

```
extism call https://raw.githubusercontent.com/extism/extism/main/wasm/code.wasm count_vowels --input="hello world"
{"count": 3}⏎ 
```