### PR TITLE
feat: add ability to list available triples using `lib versions` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ To list the available libextism versions:
 extism lib versions
 ```
 
+To list the available triples for a version:
+
+```shell
+extism lib versions v0.0.1-alpha
+```
+
 ### Install libextism
 
 To install the latest version of `libextism` to `/usr/local`, this will overwrite any existing installation at the same path:

--- a/lib.go
+++ b/lib.go
@@ -312,11 +312,30 @@ func runLibVersions(cmd *cobra.Command, args []string) error {
 
 	for _, rel := range releases {
 		name := rel.GetTagName()
-		if name == "latest" {
-			continue
-		}
+		if len(args) > 0 {
+			ok := false
+			for a := range args {
+				ok = ok || name == args[a]
+			}
 
+			if !ok {
+				continue
+			}
+		}
 		Print(name)
+
+		if len(args) > 0 {
+			for _, asset := range rel.Assets {
+				filename := asset.GetName()
+				if !strings.HasSuffix(filename, ".tar.gz") {
+					continue
+				}
+				triple := strings.TrimSuffix(strings.TrimPrefix(filename, "libextism-"), "-"+name+".tar.gz")
+				triple = strings.TrimSuffix(triple, "-main.tar.gz")
+				Print("\t" + triple)
+
+			}
+		}
 	}
 
 	return nil

--- a/lib.go
+++ b/lib.go
@@ -310,13 +310,16 @@ func runLibVersions(cmd *cobra.Command, args []string) error {
 
 	Log("Found", len(releases))
 
+	search := map[string]bool{}
+
+	for i := range args {
+		search[args[i]] = true
+	}
+
 	for _, rel := range releases {
 		name := rel.GetTagName()
 		if len(args) > 0 {
-			ok := false
-			for a := range args {
-				ok = ok || name == args[a]
-			}
+			_, ok := search[name]
 
 			if !ok {
 				continue


### PR DESCRIPTION
- `extism lib versions  <VERSION...>` will list the available triples for a version (or multiple versions)