### PR TITLE
fix: Change default `prefix` on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ extism lib versions v0.0.1-alpha
 
 ### Install libextism
 
-To install the latest version of `libextism` to `/usr/local` on macOS and Linux and `%LOCALAPPDATA%\Extism` on Windows, this will overwrite any existing installation at the same path:
+To install the latest version of `libextism` to `/usr/local` on macOS and Linux and `.` on Windows, this will overwrite any existing installation at the same path:
 
 ```shell
 sudo PATH=$PATH env extism lib install

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ extism lib versions v0.0.1-alpha
 
 ### Install libextism
 
-To install the latest version of `libextism` to `/usr/local`, this will overwrite any existing installation at the same path:
+To install the latest version of `libextism` to `/usr/local` on macOS and Linux and `%LOCALAPPDATA%\Extism` on Windows, this will overwrite any existing installation at the same path:
 
 ```shell
 sudo PATH=$PATH env extism lib install

--- a/lib.go
+++ b/lib.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -374,6 +375,20 @@ func runLibCheck(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func defaultPrefix(osName string) string {
+	switch osName {
+	case "windows":
+		dir, err := os.UserCacheDir()
+		if err != nil {
+			return "C:/"
+		}
+
+		return strings.ReplaceAll(path.Join(dir, "Extism"), "\\", "/")
+	default:
+		return "/usr/local/xxxxxxxx"
+	}
+}
+
 func LibCmd() *cobra.Command {
 	lib := &cobra.Command{
 		Use:   "lib",
@@ -394,7 +409,7 @@ func LibCmd() *cobra.Command {
 	libInstall.Flags().StringVar(&installArgs.arch, "arch", runtime.GOARCH, "The target architecture: x86_64, aarch64")
 	libInstall.Flags().StringVar(&installArgs.libc, "libc", "", "The libc implementation/compiler to use: gnu, msvc, musl")
 	libInstall.Flags().StringVar(&installArgs.triplet, "triplet", "", "CPU, vendor, and operating system (sometimes incl. libc) combined. Can be used instead of arch, os, and libc fields.")
-	libInstall.Flags().StringVar(&installArgs.prefix, "prefix", "/usr/local",
+	libInstall.Flags().StringVar(&installArgs.prefix, "prefix", defaultPrefix(runtime.GOOS),
 		"Prefix for libextism installation. libextism will be copied to $prefix/$libdir and extism.h will be copied to $prefix/$includedir")
 	libInstall.Flags().StringVar(&installArgs.libDir, "libdir", "lib", "The shared object will be installed to $prefix/$libdir")
 	libInstall.Flags().StringVar(&installArgs.includeDir, "includedir", "include", "The header file will be installed to $prefix/$includedir")
@@ -408,7 +423,7 @@ func LibCmd() *cobra.Command {
 		SilenceUsage: true,
 		RunE:         RunArgs(runLibUninstall, uninstallArgs),
 	}
-	libUninstall.Flags().StringVar(&uninstallArgs.prefix, "prefix", "/usr/local",
+	libUninstall.Flags().StringVar(&uninstallArgs.prefix, "prefix", defaultPrefix(runtime.GOOS),
 		"Prefix for existing libextism installation")
 	libUninstall.Flags().StringVar(&uninstallArgs.libDir, "libdir", "lib", "The shared object will be removed from $prefix/$libdir")
 	libUninstall.Flags().StringVar(&uninstallArgs.includeDir, "includedir", "include", "The header file will be removed from $prefix/$includedir")

--- a/lib.go
+++ b/lib.go
@@ -385,7 +385,7 @@ func defaultPrefix(osName string) string {
 
 		return strings.ReplaceAll(path.Join(dir, "Extism"), "\\", "/")
 	default:
-		return "/usr/local/xxxxxxxx"
+		return "/usr/local"
 	}
 }
 

--- a/lib.go
+++ b/lib.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -378,12 +377,7 @@ func runLibCheck(cmd *cobra.Command, args []string) error {
 func defaultPrefix(osName string) string {
 	switch osName {
 	case "windows":
-		dir, err := os.UserCacheDir()
-		if err != nil {
-			return "C:/"
-		}
-
-		return strings.ReplaceAll(path.Join(dir, "Extism"), "\\", "/")
+		return "."
 	default:
 		return "/usr/local"
 	}


### PR DESCRIPTION
Currently, the default `prefix` is `/usr/local` on all platforms. On Windows, there is no clear equivalent of `/usr/local/lib` or `/usr/local/lib`. Here are some options:
 - `C:\Program Files\Extism`: Requires Admin privileges, not part of `PATH` by default
 - `%LOCALAPPDATA\Extism`: (i.e. C:\Users\mo\AppData\Local\Extism): not part of `PATH` by default
 - `.`
 
 In the end, I settled on having `.` as the default option because the user probably wants to install it in a folder that is included in `PATH`, and if they didn't specify anything, the CLI should install in a predictable location. However, I don't have any strong opinions here
 
Current behavior:
```
PS D:\x\cli> extism lib install
Installing v0.5.5 to /usr/local
Fetching https://github.com/extism/extism/releases/download/v0.5.5/libextism-x86_64-pc-windows-msvc-v0.5.5.tar.gz
Copying extism.dll to \usr\local\lib\extism.dll
Copying extism.h to \usr\local\include\extism.h
PS D:\x\cli> cd d:\usr\local\lib\
PS D:\usr\local\lib> ls

    Directory: D:\usr\local\lib

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---          11/30/2023  4:41 PM       13258240 extism.dll
```

Note how it got installed in `D:\usr\local\lib` which is not what a Windows user expects.

New behavior:
```
PS D:\dylibso\cli\extism> go run main.go lib install
Installing v0.5.5 to .
Fetching https://github.com/extism/extism/releases/download/v0.5.5/libextism-x86_64-pc-windows-msvc-v0.5.5.tar.gz
Copying extism.dll to lib\extism.dll
Copying extism.h to include\extism.h
PS D:\dylibso\cli\extism> cd .\lib\
PS D:\dylibso\cli\extism\lib> ls

    Directory: D:\dylibso\cli\extism\lib

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---          11/30/2023  4:43 PM       13258240 extism.dll
```

I thinks this makes the CLI much more predictable on Windows