### PR TITLE
feat: gen plugin automatically initializes submodules after cloning the template repo

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -123,15 +123,8 @@ func runCmdInDir(dir, name string, args ...string) error {
 }
 
 func cloneTemplate(pdk pdkTemplate, dir, tag string) error {
-	if err := runCmdInDir("", "git", "clone", "--depth=1", pdk.Url, "--branch", tag, dir); err != nil {
+	if err := runCmdInDir("", "git", "clone", "--depth=1", pdk.Url, "--branch", tag, "--recurse-submodules", dir); err != nil {
 		return err
-	}
-
-	// initialize submodules if any
-	if _, err := os.Stat(filepath.Join(dir, ".gitmodules")); err == nil {
-		if err := runCmdInDir(dir, "git", "submodule", "update", "--init", "--recursive"); err != nil {
-			return err
-		}
 	}
 
 	// recursively check that parents are not a git repository, create an orphan branch & commit, cleanup

--- a/generate.go
+++ b/generate.go
@@ -127,6 +127,13 @@ func cloneTemplate(pdk pdkTemplate, dir, tag string) error {
 		return err
 	}
 
+	// initialize submodules if any
+	if _, err := os.Stat(filepath.Join(dir, ".gitmodules")); err == nil {
+		if err := runCmdInDir(dir, "git", "submodule", "update", "--init", "--recursive"); err != nil {
+			return err
+		}
+	}
+
 	// recursively check that parents are not a git repository, create an orphan branch & commit, cleanup
 	// otherwise, remove the git repository and assume this should be a plain directory within the parent
 	absDir, err := filepath.Abs(dir)


### PR DESCRIPTION
Fixes #87 

```
PS D:\dylibso\cli\extism> go run . generate plugin -o d:/x/xtp/c-1 -l C
Cloning into 'd:/x/xtp/c-1'...
remote: Enumerating objects: 9, done.
remote: Counting objects: 100% (9/9), done.
remote: Compressing objects: 100% (7/7), done.
remote: Total 9 (delta 0), reused 5 (delta 0), pack-reused 0
Receiving objects: 100% (9/9), done.
Submodule 'extism' (https://github.com/extism/c-pdk) registered for path 'extism'
Cloning into 'D:/x/xtp/c-1/extism'...
Submodule path 'extism': checked out '68a42171becc1712cc9c91d3feee147e5fecdb2a'
Switched to a new branch 'extism-init'
[extism-init (root-commit) 850d0a3] init: extism
 7 files changed, 69 insertions(+)
 create mode 100644 .gitignore
 create mode 100644 .gitmodules
 create mode 100644 LICENSE
 create mode 100644 Makefile
 create mode 100644 README.md
 create mode 160000 extism
 create mode 100644 src/plugin.c
Generated C plugin scaffold at d:/x/xtp/c-1
```