### PR TITLE
fix: return error when non-zero exit code in returned

### DIFF
--- a/call.go
+++ b/call.go
@@ -276,6 +276,10 @@ func runCall(cmd *cobra.Command, call *callArgs) error {
 		if call.loop > 1 {
 			fmt.Println()
 		}
+
+		if exit != 0 {
+			return errors.New(fmt.Sprintf("Returned non-zero exit code: %d", exit))
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Returns an error when a plugin call returns a non-zero exit code

See https://github.com/extism/go-pdk/issues/33