### PR TITLE
ci: minimize binary size

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
   releases:
     name: Release Go Binary
     runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: "0"
     strategy:
       matrix:
         goos: [linux, windows, darwin]
@@ -18,7 +20,7 @@ jobs:
           - goarch: arm64
             goos: windows
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: |
         bash ./scripts/set-version.sh "${{ github.event.release.tag_name }}"
     - uses: wangyoucao577/go-release-action@v1
@@ -31,3 +33,7 @@ jobs:
         extra_files: LICENSE README.md
         release_tag: ${{ github.event.release.tag_name }}
         overwrite: true
+        md5sum: false
+        sha256sum: true
+        build_flags: -trimpath
+        ldflags: '-s -w -buildid='


### PR DESCRIPTION
make released binaries reproducible
use sha256 instead of md5
make sure CGO_ENABLED=0