### PR TITLE
Add Winget package release workflow

### DIFF
--- a/.github/workflows/release_winget.yml
+++ b/.github/workflows/release_winget.yml
@@ -1,0 +1,14 @@
+on:
+  release:
+    types: released
+
+jobs:
+  release_winget:
+    name: Release Winget Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: Dylibso.Extism.CLI
+          installers-regex: '^extism-*-windows-amd64.zip$'
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Adds a new workflow file for releasing Extism.CLI to Winget.

Discussion on the Discord server remained unclear on what should be done about the existing `release.yml` file and when a release workflow should run. I've added a completely new file for now to only run the Winget release on the `released` trigger instead of on the `created` or `edited` triggers.
